### PR TITLE
Cache isn't working + check 403 errors + send original config to provider

### DIFF
--- a/src/AccessTokenCacheHandler.php
+++ b/src/AccessTokenCacheHandler.php
@@ -52,6 +52,6 @@ class AccessTokenCacheHandler
 
     public function getCacheKey(OAuth2Provider $provider, array $options): string
     {
-        return static::CACHE_KEY_PREFIX . md5(print_r($provider, true) . serialize($options));
+        return static::CACHE_KEY_PREFIX . md5(get_class($provider) . serialize($options));
     }
 }

--- a/src/AddAuthorizationHeader.php
+++ b/src/AddAuthorizationHeader.php
@@ -35,9 +35,8 @@ class AddAuthorizationHeader
 
     private function getAccessToken(): AccessToken
     {
-        $options = $this->getOptions();
         $grantType = $this->getGrantType();
-        return $this->provider->getAccessToken($grantType, $options);
+        return $this->provider->getAccessToken($grantType, $this->config);
     }
 
     private function getGrantType(): string
@@ -46,14 +45,5 @@ class AddAuthorizationHeader
             throw new \InvalidArgumentException('Config value `grant_type` needs to be specified.');
         }
         return $this->config['grant_type'];
-    }
-
-    private function getOptions(): array
-    {
-        $options = [];
-        if (!empty($this->config['scope'])) {
-            $options['scope'] = $this->config['scope'];
-        }
-        return $options;
     }
 }

--- a/src/RetryOnAuthorizationError.php
+++ b/src/RetryOnAuthorizationError.php
@@ -34,6 +34,6 @@ class RetryOnAuthorizationError
 
     private function isUnauthorizedResponse(int $retries, ResponseInterface $response = null)
     {
-        return !empty($response) && $retries < 1 && $response->getStatusCode() === 401;
+        return !empty($response) && $retries < 1 && in_array($response->getStatusCode(), [401,403]);
     }
 }


### PR DESCRIPTION
I found some problems while using this middleware to consume a Drupal 8 powered graphql server.
All small stuff:
1 - Cache wasn't working because the key generation gives a different key every request
2 - Headers in the config wasn't being sent to the provider
3 - Check for 403 errors in the Retry on Authorization Error