### PR TITLE
#14 Allow generic token_options to be passed via $config[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ $options = [
 // Any provider extending League\OAuth2\Client\Provider\AbstractProvider will do
 $provider = new Softonic\OAuth2\Client\Provider\Softonic($options);
 
-$config = ['grant_type' => 'client_credentials', 'scope' => 'myscope'];
+// Send OAuth2 parameters and use token_options for any other parameters your OAuth2 provider needs
+$config = ['grant_type' => 'client_credentials', 'scope' => 'myscope', 'token_options' => ['audience' => 'test_audience']];
 
 // Any implementation of PSR-6 Cache will do
 $cache = new \Symfony\Component\Cache\Adapter\FilesystemAdapter();

--- a/src/AddAuthorizationHeader.php
+++ b/src/AddAuthorizationHeader.php
@@ -57,8 +57,8 @@ class AddAuthorizationHeader
         }
       
         if (!empty($this->config['token_options'])) {
-            $token_options = $this->config['token_options'];
-            foreach ($token_options as $key => $value) {
+            $tokenOptions = $this->config['token_options'];
+            foreach ($tokenOptions as $key => $value) {
                 $options[$key] = $value;
             }
         }

--- a/src/AddAuthorizationHeader.php
+++ b/src/AddAuthorizationHeader.php
@@ -55,6 +55,14 @@ class AddAuthorizationHeader
         if (!empty($this->config['scope'])) {
             $options['scope'] = $this->config['scope'];
         }
+      
+        if (!empty($this->config['token_options'])) {
+            $token_options = $this->config['token_options'];
+            foreach ($token_options as $key => $value) {
+                $options[$key] = $value;
+            }
+        }
+
         return $options;
     }
 }

--- a/tests/AddAuthorizationHeaderTest.php
+++ b/tests/AddAuthorizationHeaderTest.php
@@ -171,6 +171,56 @@ class AddAuthorizationHeaderTest extends TestCase
         $this->assertSame($mockRequest, $request);
     }
 
+    public function testMiddlewareAddingAuthorizationHeaderWithTokenOptions()
+    {
+        $mockRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $mockCacheHandler = $this->createMock(\Softonic\OAuth2\Guzzle\Middleware\AccessTokenCacheHandler::class);
+
+        $config = [
+            'grant_type' => 'client_credentials',
+            'scope' => 'myscope',
+            'token_options' => ['audience' => 'test_audience'],
+        ];
+
+        $this->mockAccessToken->expects($this->once())
+            ->method('getToken')
+            ->willReturn('mytoken');
+
+        $mockCacheHandler->expects($this->once())
+            ->method('getTokenByProvider')
+            ->with($this->mockOauth2Provider)
+            ->willReturn(false);
+        $mockCacheHandler->expects($this->once())
+            ->method('saveTokenByProvider')
+            ->with(
+                $this->mockAccessToken,
+                $this->mockOauth2Provider,
+                $config
+            );
+
+        $this->mockOauth2Provider->expects($this->once())
+            ->method('getAccessToken')
+            ->with(
+                'client_credentials',
+                ['scope' => 'myscope', 'audience' => 'test_audience']
+            )
+            ->willReturn($this->mockAccessToken);
+
+        $mockRequest->expects($this->once())
+            ->method('withHeader')
+            ->with('Authorization', 'Bearer mytoken')
+            ->willReturnSelf();
+
+        $addAuthorizationHeader = new AddAuthorizationHeader(
+            $this->mockOauth2Provider,
+            $config,
+            $mockCacheHandler
+        );
+        $request = $addAuthorizationHeader($mockRequest);
+
+        $this->assertSame($mockRequest, $request);
+    }
+
     public function testMiddlewareNotNegotiatingTokenWhenIsCached()
     {
         $mockRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);


### PR DESCRIPTION
This enhancement will allow for other token options to be passed through the middleware for compatibility with OAuth2 compatible frameworks that have some "extra" requirements.