### PR TITLE
Use authorization headers from Provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - travis_retry composer update --no-interaction --prefer-source
 
 script:
+  - export XDEBUG_MODE=coverage
   - composer phpunit
 
 after_script:

--- a/src/AddAuthorizationHeader.php
+++ b/src/AddAuthorizationHeader.php
@@ -31,7 +31,11 @@ class AddAuthorizationHeader
             $this->cacheHandler->saveTokenByProvider($accessToken, $this->provider, $this->config);
         }
 
-        return $request->withHeader('Authorization', 'Bearer ' . $token);
+        foreach ($this->provider->getHeaders($token) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $request;
     }
 
     private function getAccessToken(): AccessToken

--- a/tests/AddAuthorizationHeaderTest.php
+++ b/tests/AddAuthorizationHeaderTest.php
@@ -106,6 +106,11 @@ class AddAuthorizationHeaderTest extends TestCase
             )
             ->willReturn($this->mockAccessToken);
 
+        $this->mockOauth2Provider->expects($this->once())
+            ->method('getHeaders')
+            ->with('mytoken')
+            ->willReturn(['Authorization' => 'Bearer mytoken']);
+
         $mockRequest->expects($this->once())
             ->method('withHeader')
             ->with('Authorization', 'Bearer mytoken')
@@ -132,6 +137,11 @@ class AddAuthorizationHeaderTest extends TestCase
         $this->mockAccessToken->expects($this->once())
             ->method('getToken')
             ->willReturn('mytoken');
+
+        $this->mockOauth2Provider->expects($this->once())
+            ->method('getHeaders')
+            ->with('mytoken')
+            ->willReturn(['Authorization' => 'Bearer mytoken']);
 
         $mockCacheHandler->expects($this->once())
             ->method('getTokenByProvider')
@@ -186,6 +196,11 @@ class AddAuthorizationHeaderTest extends TestCase
             ->method('getToken')
             ->willReturn('mytoken');
 
+        $this->mockOauth2Provider->expects($this->once())
+            ->method('getHeaders')
+            ->with('mytoken')
+            ->willReturn(['Authorization' => 'Bearer mytoken']);
+
         $mockCacheHandler->expects($this->once())
             ->method('getTokenByProvider')
             ->with($this->mockOauth2Provider)
@@ -235,6 +250,11 @@ class AddAuthorizationHeaderTest extends TestCase
         $this->mockAccessToken->expects($this->once())
             ->method('getToken')
             ->willReturn('mytoken');
+
+        $this->mockOauth2Provider->expects($this->once())
+            ->method('getHeaders')
+            ->with('mytoken')
+            ->willReturn(['Authorization' => 'Bearer mytoken']);
 
         $mockCacheHandler->expects($this->once())
             ->method('getTokenByProvider')
@@ -294,6 +314,11 @@ class AddAuthorizationHeaderTest extends TestCase
             ->method('withHeader')
             ->with('Authorization', 'Bearer mytoken')
             ->willReturnSelf();
+
+        $this->mockOauth2Provider->expects($this->once())
+            ->method('getHeaders')
+            ->with('mytoken')
+            ->willReturn(['Authorization' => 'Bearer mytoken']);
 
         $this->mockOauth2Provider->expects($this->never())
             ->method('getAccessToken');


### PR DESCRIPTION
Authorization headers can vary from provider to provider.
Therefore it is important, that the headers provided by the `getHeaders` method is used.