### PR TITLE
Avoid not allowed key characters for PSR-6 key

### DIFF
--- a/src/AccessTokenCacheHandler.php
+++ b/src/AccessTokenCacheHandler.php
@@ -9,7 +9,7 @@ use Psr\Cache\InvalidArgumentException;
 
 class AccessTokenCacheHandler
 {
-    const CACHE_KEY_PREFIX = 'oauth2-token-';
+    const CACHE_KEY_PREFIX = 'oauth2_token_';
 
     private $cache;
 


### PR DESCRIPTION
Otherwise InvalidArgumentException is thrown by psr-6 compliant cache implementation