### PR TITLE
Remove unused CACHE_KEY_PREFIX from AddAuthorizationHeader

### DIFF
--- a/src/AddAuthorizationHeader.php
+++ b/src/AddAuthorizationHeader.php
@@ -9,8 +9,6 @@ use Psr\Http\Message\RequestInterface;
 
 class AddAuthorizationHeader
 {
-    const CACHE_KEY_PREFIX = 'oauth2-token-';
-
     private $provider;
     private $cacheHandler;
     private $config;


### PR DESCRIPTION
This constant is defined and used in `AccessTokenCacheHandler`, but never in `AddAuthorizationHeader`.