### PR TITLE
Reverse middleware order

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -23,13 +23,13 @@ class ClientBuilder
 
         $stack->setHandler(new CurlHandler());
 
-        $stack = static::addHeaderMiddlewareToStack(
+        $stack = static::addRetryMiddlewareToStack(
             $stack,
             $oauthProvider,
             $tokenOptions,
             $cacheHandler
         );
-        $stack = static::addRetryMiddlewareToStack(
+        $stack = static::addHeaderMiddlewareToStack(
             $stack,
             $oauthProvider,
             $tokenOptions,


### PR DESCRIPTION
The retry middleware must handle the response after the header middleware, thus must be before it on the stack

Resolves: https://github.com/softonic/guzzle-oauth2-middleware/issues/24

https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html